### PR TITLE
Rename 'upload-linux' target to 'upload'

### DIFF
--- a/tutorials/mystorm-setup/source/index.rst
+++ b/tutorials/mystorm-setup/source/index.rst
@@ -79,11 +79,11 @@ Uploading your design (Mac/Linux)
 
 For Linux::
 
-  make SERIAL=/dev/ttyACM0 upload-linux
+  make SERIAL=/dev/ttyACM0 upload
 
 For Mac::
 
-  make SERIAL=/dev/cu.usbmodem1421 upload-linux
+  make SERIAL=/dev/cu.usbmodem1421 upload
 
 You may need to use a different value for ``SERIAL`` depending on your
 machine.


### PR DESCRIPTION
There was no upload-linux target in the makefile, but it looks like the phony 'upload' defaults to Linux, and it appears to work for me.