### PR TITLE
Add prerequisites for Fedora

### DIFF
--- a/chiphack-2017-install-linux.html
+++ b/chiphack-2017-install-linux.html
@@ -44,10 +44,23 @@
 	  Arachne-PNR and yosys tools later.
 	</p>
 
+        <p>
+          For Debian-based distributions, use the following command:
+        </p>
+
 	<pre>
 sudo apt-get install build-essential clang bison flex libreadline-dev \
 gawk tcl-dev libffi-dev git mercurial graphviz xdot pkg-config python \
 	  python3 libftdi-dev vim htop screen iverilog</pre>
+
+        <p>
+          For Fedora-based distributions, use the following command:
+        </p>
+
+        <pre>
+        dnf install @development-tools clang bison flex readline-devel \
+gawk tcl-devel libffi-devel git mercurial graphviz python-xdot \
+pkgconfig python python3 libftdi-devel vim htop screen iverilog</pre>
 
 	<h3>Downloading and installing IceStorm</h3>
 


### PR DESCRIPTION
This commit adds a dnf command to install the prerequisites on Fedora,
which is the equivalent of the apt-get command in the existing
documentation.